### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,6 +3,9 @@
 
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Azovlo/Cabinet/security/code-scanning/1](https://github.com/Azovlo/Cabinet/security/code-scanning/1)

To address the problem, a `permissions` block should be added to the workflow, specifying the minimal set of permissions needed. For typical Node.js CI workflows—running tests, installing dependencies—the workflow only needs to `read` repository contents, so `contents: read` is sufficient and recommended unless there are steps that require more. 
The fastest and safest way to resolve this is to insert a `permissions:` block with the value `contents: read` at the workflow root, immediately below (or above) the `on:` trigger. This change will apply to all jobs within the workflow unless overridden by a job-level `permissions` block.
No additional dependencies or code changes are needed; only the YAML configuration is updated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
